### PR TITLE
fix: COnsistent naming of repo ids 

### DIFF
--- a/src/domain.ts
+++ b/src/domain.ts
@@ -108,16 +108,16 @@ export class Domain extends Construct {
     validations.validateDomainNameLength(props.domainName);
     validations.validateDomainName(props.domainName);
 
-    this.domainInstance = new CfnDomain(this, props.domainName, props);
+    const domainId = `${props.domainName}-cfnDom`;
+    this.domainInstance = new CfnDomain(this, domainId, props);
 
     if (props.repositories) {
-      let idx = 1;
       for (const repoProps of props.repositories) {
         validations.validateRepoNameLength(repoProps.repositoryName);
         validations.validateRepoName(repoProps.repositoryName);
         validations.validateExternalConnections(repoProps.externalConnections);
 
-        const repoName = `${repoProps.repositoryName}${idx}`;
+        const repoName = `${repoProps.repositoryName}-cfnRepo`;
         const repo = new Repository(this, repoName, {
           domainName: this.props.domainName,
           ...repoProps,
@@ -125,8 +125,6 @@ export class Domain extends Construct {
 
         repo.node.addDependency(this.domainInstance);
         this.repositories.push(repo);
-
-        idx = idx + 1;
       }
     }
   }


### PR DESCRIPTION
Fixes:
- COnsistent naming of Repository Ids when array has more than 1 element such that inserting a new repository element does not break the Cloudformation stack

